### PR TITLE
feature: websocket support

### DIFF
--- a/src/main/java/com/kenya/jug/arena/config/WebSocketConfig.java
+++ b/src/main/java/com/kenya/jug/arena/config/WebSocketConfig.java
@@ -1,0 +1,22 @@
+package com.kenya.jug.arena.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        registry.addEndpoint("/ws");
+    }
+
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry registry) {
+        registry.enableSimpleBroker("/topic");
+        registry.setApplicationDestinationPrefixes("/app");
+    }
+}

--- a/src/main/java/com/kenya/jug/arena/controller/WebSocketController.java
+++ b/src/main/java/com/kenya/jug/arena/controller/WebSocketController.java
@@ -1,0 +1,17 @@
+package com.kenya.jug.arena.controller;
+
+import com.kenya.jug.arena.io.SocketMessage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.SendTo;
+import org.springframework.stereotype.Controller;
+
+@Controller
+@RequiredArgsConstructor
+public class WebSocketController {
+
+    @MessageMapping("/message")
+    @SendTo("/topic/lobby")
+    public void processMessage(SocketMessage message) {
+    }
+}

--- a/src/main/java/com/kenya/jug/arena/io/SocketMessage.java
+++ b/src/main/java/com/kenya/jug/arena/io/SocketMessage.java
@@ -1,0 +1,10 @@
+package com.kenya.jug.arena.io;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class SocketMessage {
+    private String content;
+}

--- a/src/main/java/com/kenya/jug/arena/model/EntityMetadata.java
+++ b/src/main/java/com/kenya/jug/arena/model/EntityMetadata.java
@@ -40,7 +40,9 @@ public class EntityMetadata {
     @Column(updatable = false)
     private LocalDateTime createdAt;
 
-    private boolean archived;
+    // boolean had null value issues when creating user
+    // not sure if Boolean is the right fix here.
+    private Boolean archived;
     private String version;
 
     @CreatedBy

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -23,8 +23,8 @@
 
 server.port=8080
 
-#example url jdbc:sqlite:arena.db
-spring.datasource.url=${DATASOURCE_URL}
+#example url jdbc:sqlite:arena.db  ${DATASOURCE_URL}
+spring.datasource.url=jdbc:sqlite:arena.db
 spring.datasource.driver-class-name=org.sqlite.JDBC
 
 

--- a/src/test/java/com/kenya/jug/arena/WebSocketIntegrationTest.java
+++ b/src/test/java/com/kenya/jug/arena/WebSocketIntegrationTest.java
@@ -1,0 +1,130 @@
+package com.kenya.jug.arena;
+
+import com.kenya.jug.arena.controller.WebSocketController;
+import com.kenya.jug.arena.io.SocketMessage;
+import com.kenya.jug.arena.io.UserRequest;
+import com.kenya.jug.arena.service.AppUserDetailsService;
+import com.kenya.jug.arena.service.UserServiceImpl;
+import com.kenya.jug.arena.util.JwtUtil;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpHeaders;
+import org.springframework.messaging.converter.MappingJackson2MessageConverter;
+import org.springframework.messaging.simp.stomp.*;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
+import org.springframework.web.socket.WebSocketHttpHeaders;
+import org.springframework.web.socket.client.WebSocketClient;
+import org.springframework.web.socket.client.standard.StandardWebSocketClient;
+import org.springframework.web.socket.messaging.WebSocketStompClient;
+import java.util.concurrent.TimeUnit;
+import static org.awaitility.Awaitility.await;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@TestPropertySource(locations = "classpath:application-test.properties")
+class WebSocketIntegrationTest {
+    @LocalServerPort
+    private int port;
+
+    @MockitoSpyBean
+    private WebSocketController webSocketController;
+
+    private WebSocketStompClient stompClient;
+    private StompSession stompSession;
+
+    private static final WebSocketHttpHeaders webSocketHeaders = new WebSocketHttpHeaders();
+
+    @BeforeAll
+    static void globalSetup(
+            @Autowired UserServiceImpl userService,
+            @Autowired AppUserDetailsService appUserDetailsService,
+            @Autowired JwtUtil jwtUtil
+    ) {
+        UserRequest userRequest = new UserRequest(
+                "test",
+                "user",
+                "testuser@mail.com",
+                "secret"
+        );
+        userService.createUser(userRequest);
+        var userDetails = appUserDetailsService.loadUserByUsername(userRequest.getEmail());
+        String jwtToken = jwtUtil.generateToken(userDetails);
+
+        assertNotNull(jwtToken, "JWT token is null");
+        assertTrue(jwtToken.length() > 0, "JWT token is empty");
+        webSocketHeaders.set(HttpHeaders.AUTHORIZATION, "Bearer " + jwtToken);
+    }
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        String url = "ws://localhost:" + port + "/api/v1.0/ws";
+        WebSocketClient webSocketClient = new StandardWebSocketClient();
+        this.stompClient = new WebSocketStompClient(webSocketClient);
+        this.stompClient.setMessageConverter(new MappingJackson2MessageConverter());
+        this.stompSession = this.stompClient
+                .connectAsync(url, webSocketHeaders, new StompSessionHandlerAdapter() {} , this.port)
+                .get(10, TimeUnit.SECONDS);
+    }
+
+    @Test
+    public void shouldConnect() {
+        assertNotNull(stompSession, "STOMP session is null after connection");
+        assertTrue(stompSession.isConnected(), "STOMP session is not connected");
+    }
+
+    @Test
+    void shouldReceiveMessageInController() {
+        ArgumentCaptor<SocketMessage> captor = ArgumentCaptor.forClass(SocketMessage.class);
+        SocketMessage message = new SocketMessage("Hello world");
+        stompSession.send("/app/message", message);
+
+        await().atMost(1, TimeUnit.SECONDS)
+                .untilAsserted(() ->
+                        verify(webSocketController, atLeastOnce()).processMessage(captor.capture())
+                );
+
+        verify(webSocketController, atLeastOnce()).processMessage(captor.capture());
+        SocketMessage received = captor.getValue();
+        assertEquals(
+                message.getContent(),
+                received.getContent(),
+                "Wanted: " + message.getContent() + ", but got: " + received.getContent()
+        );
+    }
+
+    @Test
+    void shouldDisconnect() {
+        stompSession.disconnect();
+
+        await()
+                .atMost(1, TimeUnit.SECONDS)
+                .until(() -> !stompSession.isConnected());
+
+        assertFalse(stompSession.isConnected(), "STOMP session is still connected");
+    }
+
+    @Test
+    void shouldThrowExceptionWhenNotAuthorized() {
+        WebSocketHttpHeaders headers = new WebSocketHttpHeaders();
+        headers.set(HttpHeaders.AUTHORIZATION, "Bearer invalid-token");
+        String url = "ws://localhost:" + port + "/api/v1.0/ws";
+
+        WebSocketClient webSocketClient = new StandardWebSocketClient();
+        WebSocketStompClient stompClient = new WebSocketStompClient(webSocketClient);
+        stompClient.setMessageConverter(new MappingJackson2MessageConverter());
+
+        assertThrows(Exception.class, () -> {
+            stompClient
+                    .connectAsync(url, headers, new StompSessionHandlerAdapter() {}, this.port)
+                    .get(10, TimeUnit.SECONDS);
+        }, "Expected exception not thrown");
+    }
+}


### PR DESCRIPTION
### Implement WebSocket server to accept player connections #4 

- [x] Implement WebSocket server configuration using Spring WebSocket. (WebSocketConfig)
- [x] Ensure clients can connect and disconnect via WebSocket.
- [x] Add basic WebSocket message handling (WebSocketController)
- [x]  test with simple messages. (WebSocketIntegrationTests)

-  Changed the `archived` type in `EntityMetadata` to `Boolean` from `boolean` because I had null value exceptions when creating user.
 